### PR TITLE
Use CDN to retrieve subtitle files

### DIFF
--- a/ext_vrtnu/basescript.js
+++ b/ext_vrtnu/basescript.js
@@ -68,7 +68,7 @@ function loadParseWebVtt() {
           DebugToConsole(xmlhttp.status + ' ' + xmlhttp.statusText);
         }
 
-        xmlhttp.open("GET", "https://s3-eu-west-1.amazonaws.com/services-mediaservices-subtitles-prod/" + videoid, true);
+        xmlhttp.open("GET", "https://services-subtitles.vrt.be/" + videoid, true);
         xmlhttp.setRequestHeader('Content-Type', 'text/plain');
 
         xmlhttp.send();

--- a/ext_vrtnu/manifest.json
+++ b/ext_vrtnu/manifest.json
@@ -7,7 +7,7 @@
   "author": "KDG",
   "permissions": [
     "*://www.vrt.be/vrtnu/*",
-    "*://s3-eu-west-1.amazonaws.com/services-mediaservices-subtitles-prod/*",
+    "*://services-subtitles.vrt.be/*",
     "tts",
     "activeTab",
     "tabs"


### PR DESCRIPTION
Instead of downloading the subtitle files from the S3 bucket where
they are hosted in use the CDN that is placed in front of it.